### PR TITLE
Fix ftdetect macro

### DIFF
--- a/ftdetect/rmarkdown.vim
+++ b/ftdetect/rmarkdown.vim
@@ -1,3 +1,3 @@
 augroup rmarkdown
-    au! BufRead,BufNewFile *.Rmd  setfiletype rmarkdown
+    au! BufRead,BufNewFile *.Rmd  set filetype=rmarkdown
 augroup END


### PR DESCRIPTION
Since vim v7.4.365, all *.Rmd files have the filetype rmd by default while this
plugin is expecting `rmarkdown` filetype. Using `set filetype=` instead of
`setf` somehow gives the `autocmd` macro a higher priority and is not
overwritten by vim default settings. I tested on vim 8.0.134 only.

This is only a workaround and it does not solve the underlying issue. The best
solution would be to use the `rmd` filetype directly, but this requires more
changes.