### PR TITLE
fix rendering of plot in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ extra functionality specific to rmarkdown.
 
 vim-rmarkdown extends pandoc's markdown syntax so
 
-    ``` 
-    {r qplot, fig.width=4, message=FALSE}
+    ```{r qplot, fig.width=4, message=FALSE}
     library(ggplot2)
     summary(cars)
     qplot(speed, dist, data=cars) + 


### PR DESCRIPTION
The Rmd example in the README.md won't render the plot or data summary with a `\n` before the rendering processing `{}` instructions.

Offering this PR incase this is not specific to my setup, OSX, pandoc.