### PR TITLE
Highlight Python syntax in code chunks

### DIFF
--- a/syntax/rmarkdown.vim
+++ b/syntax/rmarkdown.vim
@@ -7,3 +7,12 @@ exe 'syn region pandocRChunk '.
             \'contained containedin=pandocDelimitedCodeblock contains=@R'
 
 syn region pandocInlineR matchgroup=Operator start=/`r\s/ end=/`/ contains=@R concealends
+
+PandocHighlight python
+" rmarkdown recognizes embedded R differently than regular pandoc
+exe 'syn region pandocPythonChunk '. 
+            \'start=/\(```\s*{\s*python.*\n\)\@<=\_^/ ' .
+            \'end=/\_$\n\(\(\s\{4,}\)\=\(`\{3,}`*\|\~\{3,}\~*\)\_$\n\_$\)\@=/ '. 
+            \'contained containedin=pandocDelimitedCodeblock contains=@python'
+
+syn region pandocInlinePython matchgroup=Operator start=/`python\s/ end=/`/ contains=@Python concealends


### PR DESCRIPTION
I just copied the existing R section and changed r/R to python/Python. Not sure if this is the preferred way of going about it but it works for me:

![image](https://user-images.githubusercontent.com/4560057/62477114-29a48480-b75d-11e9-81a2-34008b51a2e8.png)

I have an [open issue in the syntax repo](https://github.com/vim-pandoc/vim-pandoc-syntax/issues/295) since I thought this was syntax related, but I realize I should have opened it here instead.