### PR TITLE
Add default filetype

### DIFF
--- a/ftdetect/rmarkdown.vim
+++ b/ftdetect/rmarkdown.vim
@@ -1,4 +1,4 @@
 augroup rmarkdown
-    au! BufRead,BufNewFile *.Rmd  set filetype=rmarkdown
-    au! BufRead,BufNewFile *.Rpres  set filetype=rmarkdown
+    au! BufRead,BufNewFile *.Rmd  set filetype=rmd.rmarkdown
+    au! BufRead,BufNewFile *.Rpres  set filetype=rmd.rmarkdown
 augroup END


### PR DESCRIPTION
Default filetype is **rmd** for that reason I added rmd before rmarkdown to fix compatibility issues with any other plugin uses the default. But I don't know if this plugin fails for any significant reason with that change. I have tried and so far it works very fine in general